### PR TITLE
Simple fix for n=1 inputs (fix #3)

### DIFF
--- a/convolutionalfixedsum/cfsa.py
+++ b/convolutionalfixedsum/cfsa.py
@@ -109,6 +109,23 @@ def cfsa(n: int, total: float=1.0, lower_constraints: Optional[Sequence[float]]=
     Returns:
         A vector of length n, sampling uniformly from the described area.
     """
+    # FIX: Simply return the total if n == 1
+    if n == 1:
+        if lower_constraints is None:
+            lower_constraints = [0] * n
+        if upper_constraints is None:
+            upper_constraints = [total] * n
+        # Do some checks
+        if sum(lower_constraints) >= total:
+            raise ValueError(f"Sum of lower constraints ({sum(lower_constraints)}) >= total utilisation {total}")
+        if sum(upper_constraints) <= total:
+            raise ValueError(f"Sum of upper constraints ({sum(upper_constraints)}) <= total utilisation {total}")
+        if len(lower_constraints) != n:
+            raise ValueError(f"Lower constraints should be of length {n} ({len(lower_constraints)} supplied)")
+        if len(upper_constraints) != n:
+            raise ValueError(f"Upper constraints should be of length {n} ({len(upper_constraints)} supplied)")
+        return [total]
+    
     return ivorfixedsum(n, total, lower_constraints, upper_constraints, config)
 
 

--- a/convolutionalfixedsum/cfsvr.py
+++ b/convolutionalfixedsum/cfsvr.py
@@ -226,6 +226,15 @@ def cfsd(n, total, lower_constraints=None, upper_constraints=None, signal_size=1
     normalised_upper_constraints = [upper_constraints[x] - lower_constraints[x] for x in range(n)]
     total_remaining = modified_total = -math.fsum([-total] + lower_constraints)
 
+    # Raise an error if any of the upper constraints were smaller than the lower constraints
+    for normalised_upper_constraint in normalised_upper_constraints:
+        if normalised_upper_constraint < 0:
+            raise ValueError(f"Upper constraints should be larger than lower constraints")
+    # Quick Fix: Return if total_remaining still equals 0, which means upper is the same as lower constraint
+    if total_remaining == 0:
+        return CFSResult(total, n, lower_constraints, upper_constraints, signal_size, rescale_output,
+                         False, retries, 0, lower_constraints)
+
     # Sort the upper constraints from low to high and make a map back
     sorted_uc, indexes = zip(*sorted(([uc, x] for x, uc in enumerate(normalised_upper_constraints)), reverse=True))
     for retries_used in range(retries):

--- a/convolutionalfixedsum/cfsvr.py
+++ b/convolutionalfixedsum/cfsvr.py
@@ -215,6 +215,12 @@ def cfsd(n, total, lower_constraints=None, upper_constraints=None, signal_size=1
         raise ValueError(f"Lower constraints should be of length {n} ({len(lower_constraints)} supplied)")
     if len(upper_constraints) != n:
         raise ValueError(f"Upper constraints should be of length {n} ({len(upper_constraints)} supplied)")
+    
+    # FIX: Simply return the total if n == 1
+    if n == 1:
+        return CFSResult(total, n, lower_constraints, upper_constraints, signal_size, rescale_output,
+                         False, retries, 0, [total]
+                        )
 
     # Perform normalisation by setting all lower constraints to 0
     normalised_upper_constraints = [upper_constraints[x] - lower_constraints[x] for x in range(n)]

--- a/tests/single_input.py
+++ b/tests/single_input.py
@@ -1,0 +1,25 @@
+"""
+single_input
+****
+
+:author: Jordan Sun <zhuoran.sun@wustl.edu> (2025)
+:license:  BSD-3-Clause license
+
+Tests the fix for single input case in both CFSVR and CFSA to avoid exceptions.
+"""
+
+import pytest
+
+import convolutionalfixedsum
+
+n = 1
+total = 0.5
+upper_constraints = [0.7]
+
+def test_cfsvr_single_input():
+    result = convolutionalfixedsum.cfsn(n, total=total, upper_constraints=upper_constraints)
+    assert result == [total]
+
+def test_cfsa_single_input():
+    result = convolutionalfixedsum.cfsa(n, total=total, upper_constraints=upper_constraints)
+    assert result == [total]

--- a/tests/single_input.py
+++ b/tests/single_input.py
@@ -5,7 +5,7 @@ single_input
 :author: Jordan Sun <zhuoran.sun@wustl.edu> (2025)
 :license:  BSD-3-Clause license
 
-Tests the fix for single input case in both CFSVR and CFSA to avoid exceptions.
+Tests the fix for single input and same constraint case in both CFSVR and CFSA to avoid exceptions.
 """
 
 import pytest
@@ -23,3 +23,16 @@ def test_cfsvr_single_input():
 def test_cfsa_single_input():
     result = convolutionalfixedsum.cfsa(n, total=total, upper_constraints=upper_constraints)
     assert result == [total]
+
+n = 4
+total = 1.0
+lower_constraints = [0.1, 0.2, 0.3, 0.4]
+upper_constraints = lower_constraints
+
+def test_cfsvr_same_constraint():
+    result = convolutionalfixedsum.cfsn(n, total=total, lower_constraints=lower_constraints, upper_constraints=upper_constraints)
+    assert result == lower_constraints
+
+def test_cfsa_same_constraint():
+    result = convolutionalfixedsum.cfsa(n, total=total, lower_constraints=lower_constraints, upper_constraints=upper_constraints)
+    assert result == lower_constraints


### PR DESCRIPTION
When n=1 for cfsn and cfsa, simply return `[total]` as the result after checking the other inputs are well formed.
This should prevent the functions from crashing when n=1.